### PR TITLE
[improvement] better map builder

### DIFF
--- a/Scripts/challenges.lua
+++ b/Scripts/challenges.lua
@@ -191,6 +191,28 @@ function challenges.createEmptyMap(width, height)
 	return m
 end
 
+function challenges.convertTableToMap(table)
+  	local map = {}
+	local _mapAssoc = {}
+	_mapAssoc[0] = nil
+	_mapAssoc[1] = "C"
+	_mapAssoc[2] = "H"
+	_mapAssoc[3] = "S"
+	_mapAssoc[4] = "STORE"
+	map[0] = {}
+	for i,row in ipairs(table) do
+		for j,value in ipairs(row) do
+			if value > 0 then
+				map[j][i] = _mapAssoc[value]
+			end
+		end	
+	end
+	map[j+1] = {}
+	map.width = j
+	map.height = i
+	return map
+end
+
 function challenges.setMessage(msg)
 	if currentTutBox then
 		TUT_BOX_X = currentTutBox.x


### PR DESCRIPTION
Hey there I'm just working on a better/faster way to create maps in challenges und I came up with the following solution:

it's much faster to write a map like this:

``` lua
local _map = {
  {1,2,0,1,1,1,0,1,1,1,},
  {1,2,3,1,4,1,0,1,2,1,},
  {1,2,1,1,1,1,0,1,1,1,},
  {1,0,1,0,0,1,0,0,0,1,},
  {1,1,1,1,1,1,2,1,0,1,},
  {1,0,0,0,0,0,1,1,0,1,},
  {1,1,1,1,1,1,1,1,1,1,}
}
```

with the convention to interpret `1 as 'C'`, `2 as 'H'`, `3 as 'S'` and `4 as 'STORE'` one can easily 'design' maps.

the convert-code should then be something like:

``` lua
function challenges.convertTableToMap(table)
  local map = {}
  local _mapAssoc = {}
  _mapAssoc[0] = nil
  _mapAssoc[1] = "C"
  _mapAssoc[2] = "H"
  _mapAssoc[3] = "S"
  _mapAssoc[4] = "STORE"

  for i,row in ipairs(table) do
    for j,value in ipairs(row) do
      if value > 0 then
        map[j][i] = _mapAssoc[value]
      end
    end
  end
  return map
end
```
